### PR TITLE
ui: Fix sorting

### DIFF
--- a/pkg/pgantt/state_manager.go
+++ b/pkg/pgantt/state_manager.go
@@ -123,35 +123,17 @@ func (s *StateManager) PlanningData(phid string) *PlanningData {
 	plan.Data = make([]Task, 0)
 	plan.Links = make([]Link, 0)
 
-	taskMap := make(map[string]bool)
-	var add func(t *PTask)
-	add = func(t *PTask) {
-		if _, added := taskMap[t.Task.Id]; added {
-			return
-		}
-
-		if t.Task.Parent != "" {
-			add(tasks[t.Task.Parent])
-		}
-
-		taskMap[t.Task.Id] = true
-		plan.Data = append(plan.Data, t.Task)
-		for _, link := range t.Links {
+	for phid := range tasks {
+		task := tasks[phid]
+		plan.Data = append(plan.Data, task.Task)
+		for _, link := range task.Links {
 			plan.Links = append(plan.Links, *link)
 		}
 	}
 
-	taskPhids := make([]string, 0, len(tasks))
-	for phid := range tasks {
-		taskPhids = append(taskPhids, phid)
-	}
-
-	sort.Strings(taskPhids)
-
-	for _, phid := range taskPhids {
-		task := tasks[phid]
-		add(task)
-	}
+	sort.Slice(plan.Data[:], func(i, j int) bool {
+		return plan.Data[i].Id < plan.Data[j].Id
+	})
 
 	sort.Slice(plan.Links[:], func(i, j int) bool {
 		return plan.Links[i].Id < plan.Links[j].Id

--- a/ui/src/actions/planning.js
+++ b/ui/src/actions/planning.js
@@ -19,25 +19,56 @@
 
 export const PLAN_SET = 'PLAN_SET';
 
-function byDateAgeFn(a, b) {
-  // Order by start date.
-  // Replace "" with "Z" so the tasks with no starting date appear below.
-  var aStartDate = a.start_date || "Z";
-  var bStartDate = b.start_date || "Z";
-  if (aStartDate < bStartDate) {
-    return -1;
-  } else if (aStartDate > bStartDate) {
-    return 1;
+export function planSet(plan) {
+  // taskId -> parentTaskId
+  let parents = new Map();
+  for (var i = 0; i < plan.data.length; i++) {
+    parents.set(plan.data[i].id, plan.data[i].parent)
   }
 
-  // Order by task age.
-  var aTaskIDNumber = parseInt(a.url.split("T")[1])
-  var bTaskIDNumber = parseInt(b.url.split("T")[1])
-  return aTaskIDNumber - bTaskIDNumber;
-}
+  // taskId -> how many ancestor tasks it has
+  let _levels = new Map();
+  function level(taskId) {
+    if (_levels.has(taskId)) {
+      return _levels.get(taskId);
+    }
+    let l = 0;
+    if (parents.has(taskId)) {
+      l = 1 + level(parents.get(taskId));
+    }
+    _levels.set(taskId, l);
+    return l;
+  }
 
-export function planSet(plan) {
-  plan.data.sort(byDateAgeFn);
+  function byLevelDateAgeFn(a, b) {
+    // Order by number of ancestors.
+    let levelDelta = level(a.id) - level(b.id);
+    if (levelDelta != 0) {
+      return levelDelta;
+    }
+
+    // Order by start date.
+    // Replace "" with "Z" so the tasks with no starting date appear below.
+    var aStartDate = a.start_date || "Z";
+    var bStartDate = b.start_date || "Z";
+    if (aStartDate < bStartDate) {
+      return -1;
+    } else if (aStartDate > bStartDate) {
+      return 1;
+    }
+  
+    // Order by task age.
+    var aTaskIDNumber = parseInt(a.url.split("T")[1])
+    var bTaskIDNumber = parseInt(b.url.split("T")[1])
+    return aTaskIDNumber - bTaskIDNumber;
+  }
+  
+  // The tasks order must be stable. Successive plans are compared to figure
+  // out whether an expensive render is needed.
+  // The sorting is done first by level (number of ancestors). Gantt will
+  // iterate the sorted tasks to place the children under their parents, so
+  // it all goes well in the end.
+  plan.data.sort(byLevelDateAgeFn);
 
   return {
     type: PLAN_SET,


### PR DESCRIPTION
Gantt complains that the (parent) task cannot be found when it sees
a child task before it sees its parent task.

Maybe it would work simpler if we use https://docs.dhtmlx.com/gantt/desktop__sorting.html#customsortingfunctions but it works fine like this.